### PR TITLE
Support local packages dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -17,6 +17,15 @@
         "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
         "version" : "509.1.1"
       }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "9234124cff5e22e178988c18d8b95a8ae8007f76",
+        "version" : "5.1.2"
+      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,10 @@ let package = Package(
       url: "https://github.com/apple/swift-argument-parser",
       from: "1.3.0"
     ),
+    .package(
+      url: "https://github.com/jpsim/Yams.git",
+      from: "5.1.2"
+    ),
   ],
   targets: [
     .target(
@@ -54,6 +58,7 @@ let package = Package(
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftParser", package: "swift-syntax"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
+        .product(name: "Yams", package: "Yams"),
       ]
     ),
     .plugin(

--- a/Sources/SwordCommand/Configuration.swift
+++ b/Sources/SwordCommand/Configuration.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+struct Configuration: Codable {
+  struct LocalPackage: Codable {
+    let path: String
+    let targets: [String]
+  }
+
+  let localPackages: [LocalPackage]
+
+  private enum CodingKeys: String, CodingKey {
+    case localPackages = "local_packages"
+  }
+}

--- a/Sources/SwordCommand/SwordCommand.swift
+++ b/Sources/SwordCommand/SwordCommand.swift
@@ -3,6 +3,7 @@ import Foundation
 import SwiftParser
 import SwiftSyntax
 import SwordGenerator
+import Yams
 
 @main
 struct SwordCommand: ParsableCommand {
@@ -13,7 +14,9 @@ struct SwordCommand: ParsableCommand {
   @Option
   var output: String
 
-  func run() throws {
+  mutating func run() throws {
+    try loadLocalPackagesIfNeeded()
+
     let sourceFiles = try inputs.map { path in
       let url = URL(filePath: path)
       let source = try String(contentsOf: url)
@@ -35,5 +38,31 @@ struct SwordCommand: ParsableCommand {
       targets: targets,
       output: output
     )
+  }
+
+  mutating private func loadLocalPackagesIfNeeded() throws {
+    let fileManager = FileManager.default
+    let configurationFilePath = URL(filePath: fileManager.currentDirectoryPath).appending(path: ".sword.yml")
+
+    guard fileManager.fileExists(atPath: configurationFilePath.path()) else { return }
+
+    let data = try Data(contentsOf: configurationFilePath)
+    let configuration = try YAMLDecoder().decode(Configuration.self, from: data)
+
+    for localPackage in configuration.localPackages {
+      targets.append(contentsOf: localPackage.targets)
+
+      let inputPath = URL(filePath: fileManager.currentDirectoryPath)
+        .appending(path: localPackage.path)
+        .appending(path: "Sources")
+      if let enumerator = fileManager.enumerator(atPath: inputPath.path()) {
+        for case let filePath as String in enumerator {
+          if filePath.hasSuffix(".swift") {
+            let fullFilePath = inputPath.appending(path: filePath)
+            inputs.append(fullFilePath.path())
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Supporting local packages dependencies for Xcode projects.

As you add a `.sword.yml` file into your Xcode project's root directory, Sword read the file and generate your dependency graph considering local packages.

```yml
local_packages:
  - path: PackageA
    targets:
      - DependencyA
      - DependencyB
  - path: PackageB
    targets:
      - DependencyC
      - DependencyD
```