### PR TITLE
Support Weak Reference Scope

### DIFF
--- a/Examples/SwiftPMBased/Package/Package.swift
+++ b/Examples/SwiftPMBased/Package/Package.swift
@@ -45,13 +45,6 @@ let package = Package(
       ]
     ),
     .target(
-      name: "ComponentRegistration",
-      dependencies: [
-        "ComponentApp",
-        .product(name: "Sword", package: "sword"),
-      ]
-    ),
-    .target(
       name: "ComponentUser",
       dependencies: [
         "ComponentApp",
@@ -97,7 +90,6 @@ let package = Package(
     .target(
       name: "UIRegistration",
       dependencies: [
-        "ComponentRegistration",
         "DataRepository",
         "CommonUI",
         .product(name: "Sword", package: "sword"),
@@ -124,7 +116,6 @@ let package = Package(
       name: "MainScene",
       dependencies: [
         "ComponentApp",
-        "ComponentRegistration",
         "ComponentUser",
         "DataModel",
         "DataAPIClientDefault",

--- a/Examples/SwiftPMBased/Package/Sources/ComponentRegistration/RegistrationComponent.swift
+++ b/Examples/SwiftPMBased/Package/Sources/ComponentRegistration/RegistrationComponent.swift
@@ -1,6 +1,0 @@
-import ComponentApp
-import Sword
-
-@Subcomponent(of: AppComponent.self)
-public final class RegistrationComponent {
-}

--- a/Examples/SwiftPMBased/Package/Sources/MainScene/OnboardingNavigation.swift
+++ b/Examples/SwiftPMBased/Package/Sources/MainScene/OnboardingNavigation.swift
@@ -1,4 +1,4 @@
-import ComponentRegistration
+import ComponentApp
 import SwiftUI
 import UIOnboarding
 import UIRegistration
@@ -11,7 +11,7 @@ enum OnboardingNavigationRoute: Hashable {
 struct OnboardingNavigation: View {
   @State private var navigationPath = [OnboardingNavigationRoute]()
 
-  let component: RegistrationComponent
+  let component: AppComponent
   let onLoggedIn: () -> Void
 
   var body: some View {

--- a/Examples/SwiftPMBased/Package/Sources/MainScene/RootNavigation.swift
+++ b/Examples/SwiftPMBased/Package/Sources/MainScene/RootNavigation.swift
@@ -34,7 +34,7 @@ struct RootNavigation: View {
       )
     case .notLoggedIn:
       OnboardingNavigation(
-        component: component.makeRegistrationComponent(),
+        component: component,
         onLoggedIn: {
           withAnimation {
             navigationState = .loggedIn

--- a/Examples/SwiftPMBased/Package/Sources/UIRegistration/RegistrationViewModel.swift
+++ b/Examples/SwiftPMBased/Package/Sources/UIRegistration/RegistrationViewModel.swift
@@ -1,4 +1,4 @@
-import ComponentRegistration
+import ComponentApp
 import DataRepository
 import Foundation
 import Observation
@@ -12,8 +12,8 @@ enum RegistrationAlertKind {
 }
 
 @Dependency(
-  registeredTo: RegistrationComponent.self,
-  scopedWith: .single
+  registeredTo: AppComponent.self,
+  scopedWith: .weakReference
 )
 @Observable
 public final class RegistrationViewModel {

--- a/Examples/SwiftPMBased/SNS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/SwiftPMBased/SNS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -17,6 +17,15 @@
         "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
         "version" : "509.1.1"
       }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "9234124cff5e22e178988c18d8b95a8ae8007f76",
+        "version" : "5.1.2"
+      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -90,7 +90,7 @@ let package = Package(
       name: "Sword",
       dependencies: [
         "SwordFoundation",
-        "SwordMacros"
+        "SwordMacros",
       ]
     ),
   ]

--- a/Package.swift
+++ b/Package.swift
@@ -89,6 +89,7 @@ let package = Package(
     .target(
       name: "Sword",
       dependencies: [
+        "SwordFoundation",
         "SwordMacros"
       ]
     ),

--- a/README.md
+++ b/README.md
@@ -398,9 +398,8 @@ struct UserNavigation: View {
 | Subcomponent | ✅ Supported |
 | Component Arguments | ✅ Supported |
 | Single Scope | ✅ Supported |
-| Weak Reference Scope | 🚧 TBD |
+| Weak Reference Scope | ✅ Supported |
 | Assisted Injection | ✅ Supported |
-| Multi Binding | 🚧 TBD |
 | Missing Dependency Error | ✅ Supported |
 | Duplicate Dependency Error | ✅ Supported |
 | Cycle Dependency Error | 🚧 TBD |

--- a/Sources/Sword/Component.swift
+++ b/Sources/Sword/Component.swift
@@ -6,6 +6,7 @@ public protocol Component: AnyObject {}
   member,
   names: named(_instanceStore),
   named(withSingle(_:_:)),
+  named(withWeakReference(_:_:)),
   arbitrary
 )
 @attached(

--- a/Sources/Sword/Dependency.swift
+++ b/Sources/Sword/Dependency.swift
@@ -1,4 +1,4 @@
-import Foundation
+import SwordFoundation
 
 @attached(peer)
 public macro Dependency(

--- a/Sources/Sword/Provider.swift
+++ b/Sources/Sword/Provider.swift
@@ -1,4 +1,4 @@
-import Foundation
+import SwordFoundation
 
 @attached(peer)
 public macro Provider(

--- a/Sources/Sword/Scope.swift
+++ b/Sources/Sword/Scope.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-public enum Scope {
-  case single
-}

--- a/Sources/Sword/Subcomponent.swift
+++ b/Sources/Sword/Subcomponent.swift
@@ -11,6 +11,7 @@ public protocol Subcomponent: Component {
   names: named(parent),
   named(_instanceStore),
   named(withSingle(_:_:)),
+  named(withWeakReference(_:_:)),
   arbitrary
 )
 @attached(

--- a/Sources/SwordFoundation/Scope.swift
+++ b/Sources/SwordFoundation/Scope.swift
@@ -1,0 +1,3 @@
+public enum Scope: String {
+  case single
+}

--- a/Sources/SwordFoundation/Scope.swift
+++ b/Sources/SwordFoundation/Scope.swift
@@ -1,3 +1,4 @@
 public enum Scope: String {
   case single
+  case weakReference
 }

--- a/Sources/SwordGenerator/Extension/Scope+methodName.swift
+++ b/Sources/SwordGenerator/Extension/Scope+methodName.swift
@@ -1,8 +1,6 @@
-import Foundation
+import SwordFoundation
 
-enum Scope: String {
-  case single
-
+extension Scope {
   var methodName: String {
     switch self {
     case .single:

--- a/Sources/SwordGenerator/Extension/Scope+methodName.swift
+++ b/Sources/SwordGenerator/Extension/Scope+methodName.swift
@@ -5,6 +5,8 @@ extension Scope {
     switch self {
     case .single:
       "withSingle"
+    case .weakReference:
+      "withWeakReference"
     }
   }
 }

--- a/Sources/SwordMacros/ComponentMacro.swift
+++ b/Sources/SwordMacros/ComponentMacro.swift
@@ -77,6 +77,16 @@ public struct ComponentMacro {
     }
     """
   }
+  static func withWeakReferenceFunction(accessModifier: String? = nil) -> DeclSyntax {
+    """
+    \(raw: accessModifier ?? "") func withWeakReference<T: AnyObject>(
+    _ function: String = #function,
+    _ factory: () -> T
+    ) -> T {
+    _instanceStore.withWeakReference(function, factory)
+    }
+    """
+  }
 }
 
 extension ComponentMacro: ExtensionMacro {
@@ -133,6 +143,7 @@ extension ComponentMacro: MemberMacro {
     return storedProperties(for: componentArguments, accessModifier: accessModifier) + [
       initializer(arguments: componentArguments, accessModifier: accessModifier),
       withSingleFunction(accessModifier: accessModifier),
+      withWeakReferenceFunction(accessModifier: accessModifier),
       instanceStoreVariable,
     ]
   }

--- a/Sources/SwordMacros/SubcomponentMacro.swift
+++ b/Sources/SwordMacros/SubcomponentMacro.swift
@@ -116,6 +116,7 @@ extension SubcomponentMacro: MemberMacro {
           accessModifier: accessModifier
         ),
         ComponentMacro.withSingleFunction(accessModifier: accessModifier),
+        ComponentMacro.withWeakReferenceFunction(accessModifier: accessModifier),
         ComponentMacro.instanceStoreVariable,
       ]
   }

--- a/Tests/SwordMacrosTests/ComponentMacroTests.swift
+++ b/Tests/SwordMacrosTests/ComponentMacroTests.swift
@@ -35,6 +35,13 @@ final class ComponentMacroTests: XCTestCase {
                 _instanceStore.withSingle(function, factory)
             }
 
+            func withWeakReference<T: AnyObject>(
+                _ function: String = #function,
+                _ factory: () -> T
+            ) -> T {
+                _instanceStore.withWeakReference(function, factory)
+            }
+
             private let _instanceStore = InstanceStore()
         }
 
@@ -69,6 +76,13 @@ final class ComponentMacroTests: XCTestCase {
                 _ factory: () -> T
             ) -> T {
                 _instanceStore.withSingle(function, factory)
+            }
+
+            public func withWeakReference<T: AnyObject>(
+                _ function: String = #function,
+                _ factory: () -> T
+            ) -> T {
+                _instanceStore.withWeakReference(function, factory)
             }
 
             private let _instanceStore = InstanceStore()

--- a/Tests/SwordMacrosTests/SubcomponentMacroTests.swift
+++ b/Tests/SwordMacrosTests/SubcomponentMacroTests.swift
@@ -43,6 +43,13 @@ final class SubcomponentMacroTests: XCTestCase {
                 _instanceStore.withSingle(function, factory)
             }
 
+            func withWeakReference<T: AnyObject>(
+                _ function: String = #function,
+                _ factory: () -> T
+            ) -> T {
+                _instanceStore.withWeakReference(function, factory)
+            }
+
             private let _instanceStore = InstanceStore()
         }
 
@@ -88,6 +95,13 @@ final class SubcomponentMacroTests: XCTestCase {
                 _ factory: () -> T
             ) -> T {
                 _instanceStore.withSingle(function, factory)
+            }
+
+            public func withWeakReference<T: AnyObject>(
+                _ function: String = #function,
+                _ factory: () -> T
+            ) -> T {
+                _instanceStore.withWeakReference(function, factory)
             }
 
             private let _instanceStore = InstanceStore()


### PR DESCRIPTION

For example, if you want to share `RegistrationViewModel` with some screens, you can use `.weakReference` scope as following:

```swift
@Dependency(
  registeredTo: AppComponent.self,
  scopedWith: .weakReference
)
@Observable
public final class RegistrationViewModel {
  private(set) var username = ""
  private(set) var password = ""
  ...
  func onRegisterButtonTapped() async {
    ...
    try await userRepository.registerUser(username: username, password: password)
    ...
  }
  ...
}
```

```swift
struct OnboardingNavigation: View {
  ...
  var body: some View {
    NavigationStack(path: $navigationPath) {
      OnboardingScreen(
        ...
      )
      .navigationDestination(for: OnboardingNavigationRoute.self) { route in
        switch route {
        case .registrationUsername:
          RegistrationUsernameScreen(
            viewModel: component.registrationViewModel,
            ...
          )
        case .registrationPassword:
          RegistrationPasswordScreen(
            viewModel: component.registrationViewModel,
            ...
          )
        }
      }
    }
  }
}
```

```swift
public struct RegistrationUsernameScreen: View {
  private let viewModel: RegistrationViewModel
  ...

  public var body: some View {
    RegistrationUsernameContent(
      username: viewModel.username,
      ...
    )
  }
}
```

```swift
public struct RegistrationPasswordScreen: View {
  private let viewModel: RegistrationViewModel
  ...
  public var body: some View {
    RegistrationPasswordContent(
      password: viewModel.password,
      ...
    )
  ...
  }
}
```