### PR TITLE
Use isDAG for detecting cycles

### DIFF
--- a/Sources/SwordGenerator/Model/BindingGraph.swift
+++ b/Sources/SwordGenerator/Model/BindingGraph.swift
@@ -26,6 +26,10 @@ final class BindingGraph {
     network.vertices
   }
 
+  var isDAG: Bool {
+    network.isDAG
+  }
+
   var cycles: [[Node]] {
     network.detectCycles()
   }

--- a/Sources/SwordGenerator/Parser/Validator/BindingGraphValidator.swift
+++ b/Sources/SwordGenerator/Parser/Validator/BindingGraphValidator.swift
@@ -66,7 +66,7 @@ struct BindingGraphValidator {
         )
       )
     }
-    if bindingGraph.cycles.isEmpty {
+    if bindingGraph.isDAG {
       for binding in bindingsByKey.values.flatMap({ $0 }) {
         switch binding.kind {
         case .registration(_, _, _, let scope):


### PR DESCRIPTION
The `Graph.detectCycles` method is somewhat heavy. Therefore, use `Graph.isDAG` instead.